### PR TITLE
feat: add total aircraft to 'metric' and 'me' endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+# IDE
+.vscode/
+*.code-workspace

--- a/app.py
+++ b/app.py
@@ -151,6 +151,7 @@ async def metrics():
         "adsb_api_beast_total_receivers {}".format(len(provider.beast_receivers)),
         "adsb_api_beast_total_clients {}".format(len(provider.beast_clients)),
         "adsb_api_mlat_total {}".format(len(provider.mlat_sync_json)),
+        "adsb_api_aircraft_total {}".format(provider.aircraft_totalcount),
     ]
     return Response(content="\n".join(metrics), media_type="text/plain")
 
@@ -187,6 +188,11 @@ async def api_me(
             "mlat": mlat_clients,
         },
         "client_ip": client_ip,
+        "global": {
+            "beast": len(provider.beast_clients),
+            "mlat": len(provider.mlat_clients),
+            "planes": provider.aircraft_totalcount,
+        },
     }
 
     return response

--- a/utils/provider.py
+++ b/utils/provider.py
@@ -8,7 +8,7 @@ import aiohttp
 import bcrypt
 
 from .reapi import ReAPI
-from .settings import REAPI_ENDPOINT
+from .settings import REAPI_ENDPOINT, ADSBLOL_HUB_HTTP
 
 
 class Provider(object):
@@ -18,6 +18,7 @@ class Provider(object):
         self.mlat_sync_json = {}
         self.mlat_totalcount_json = {}
         self.mlat_clients = {}
+        self.aircraft_totalcount = 0
         self.ReAPI = ReAPI(REAPI_ENDPOINT)
 
     async def startup(self):
@@ -35,6 +36,14 @@ class Provider(object):
         try:
             while True:
                 try:
+                    # global update
+                    print("Fetching data from", ADSBLOL_HUB_HTTP)
+                    async with self.client_session.get(
+                        f"{ADSBLOL_HUB_HTTP}/data/stats.json"
+                    ) as resp:
+                        data = await resp.json()
+                    self.aircraft_totalcount = data["aircraft_with_pos"]
+
                     # clients update
                     ips = ["ingest-readsb:150"]
                     print("Fetching data from", ips)
@@ -80,7 +89,7 @@ class Provider(object):
                     ) as resp:
                         data = await resp.json()
                     self.mlat_clients = data
-
+                    
                     print("Looped..")
                     await asyncio.sleep(1)
                 except Exception as e:

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -6,3 +6,4 @@ REDIS_TTL = int(os.getenv("ADSBLOL_REDIS_TTL", "5"))
 REAPI_ENDPOINT = os.getenv(
     "ADSBLOL_REAPI_ENDPOINT", "http://reapi-readsb:30152/re-api/"
 )
+ADSBLOL_HUB_HTTP = os.getenv("ADSBLOL_HUB_HTTP", "http:://hub-readsb:150")


### PR DESCRIPTION
This PR adds a 'global' field to the `/api/0/me` endpoint that contains the total BEAST count, MLAT count and aircraft count. It also adds the total aircraft to the `/metric` endpoint.
