### PR TITLE
Change the distance helper program

### DIFF
--- a/distance/distance.cpp
+++ b/distance/distance.cpp
@@ -6,44 +6,33 @@
 #include "PolyUtil.hpp"
 
 void usage() {
-    std::cout << "Usage:\n\n\tdistance latP lngP latA lngA [latB lngB]\n\n\tprint the sperical distance of point P from point A or of P from the great circle between A and B\n";
+    std::cout << "Usage:\n\n\tdistance latP lngP latA lngA latB lngB absoluteDelta relativeDelta\n\n\tcheck if a point P is within the given thresholdsa (in meters or percentage of the distance A-B) of the great circle route between A and B.\n";
 }
 
 int main(int argc, char** argv) {
-	if (argc != 5 && argc != 7) {
+	if (argc != 9) {
 		usage();
 		exit(1);
 	}
-	std::string pLat = argv[1];
-	std::string pLng = argv[2];
-	std::string aLat = argv[3];
-	std::string aLng = argv[4];
-
-	LatLng p = { std::stod(pLat), std::stod(pLng) };
-	LatLng a = { std::stod(aLat), std::stod(aLng) };
-
-	std::string bLat, bLng;
-	LatLng b = { 0.0, 0.0 };
+	LatLng p = { std::stod(argv[1]), std::stod(argv[2]) };
+	LatLng a = { std::stod(argv[3]), std::stod(argv[4]) };
+	LatLng b = { std::stod(argv[5]), std::stod(argv[6]) };
+	double distThreshold = std::stod(argv[7]) * 1852;
+	double distPercentage = std::stod(argv[8]);
 	
 	double distPA = SphericalUtil::computeDistanceBetween(p, a);
+	double distPB = SphericalUtil::computeDistanceBetween(p, b);
+	double distAB = SphericalUtil::computeDistanceBetween(a, b);
+
+	// calculate if the point is within the given tolerance of the route
+	std::vector<LatLng> route = { a, b};
+	double threshold = std::max(distThreshold, distPercentage * distAB / 100.0);
+	bool withinThreshold = PolyUtil::isLocationOnPath(p, route, threshold);
 
 	std::cout << "{\"distPA\": " << distPA / 1852.0;
-
-	if (argc ==7) {
-		std::string bLat = argv[5];
-		std::string bLng = argv[6];
-		LatLng b = { std::stod(bLat), std::stod(bLng) };
-
-		double distPB = SphericalUtil::computeDistanceBetween(p, b);
-		std::cout << ",\"distPB\": " << distPB / 1852.0;
-
-		double distAB = SphericalUtil::computeDistanceBetween(a, b);
-		std::cout << ",\"distAB\": " << distAB / 1852.0;
-
-		double distPAB = PolyUtil::distanceToLine(p, a, b);
-		std::cout << ",\"distPAB\": " << distPAB / 1852.0;
-	}
-	std::cout << "}";
+	std::cout << ",\"distPB\": " << distPB / 1852.0;
+	std::cout << ",\"distAB\": " << distAB / 1852.0;
+	std::cout << ",\"withinThreshold\": " << withinThreshold << "}";
 
 	return 0;
 }

--- a/src/adsb_api/utils/plausible.py
+++ b/src/adsb_api/utils/plausible.py
@@ -10,6 +10,7 @@ def plausible(
     airportBLat: str,
     airportBLon: str,
 ):
+    # check if the position is within 50nm or 10% of the total distance of the great circle route
     distanceResult = subprocess.run(
         [
             "/usr/local/bin/distance",
@@ -19,15 +20,11 @@ def plausible(
             airportALon,
             airportBLat,
             airportBLon,
+            "50",
+            "10"
         ],
         capture_output=True,
     )
     distance = orjson.loads(distanceResult.stdout)
-    # lame assumption that the plane should be within
-    # 50nm or 5% or route distance of the great circle route
-    # no concern for direction, no handling of multi segment routes
-    threshold = 50
-    fivePercent = distance["distAB"] / 20
-    if fivePercent > threshold:
-        threshold = fivePercent
-    return distance["distPAB"] < threshold, distance["distAB"]
+    return distance['withinThreshold'], distance['distAB']
+


### PR DESCRIPTION
Given a bug in the C++ code that does the spherical calculations, flights crossing the dateline had the distance from their route calculated incorrectly. To work around this, we now pass in an absolute and relative (percentage of route length) distance into the helper app and it returns whether the plane position is within that threshold from the great circle route.

Also, based on some real world examples, I ended up increasing the threshold percentage from 5% to 10% (NRT-DEN flight right above PDX).