### PR TITLE
Adjust width of plausibility band

### DIFF
--- a/src/adsb_api/utils/plausible.py
+++ b/src/adsb_api/utils/plausible.py
@@ -21,7 +21,7 @@ def plausible(
             airportBLat,
             airportBLon,
             "50",
-            "10"
+            "20"
         ],
         capture_output=True,
     )


### PR DESCRIPTION
Testing with a lot more data shows that quite a few planes diverge more than 10% from their route. The highest values that I have seen so far on correct routes appear to be around 16% - so setting this to 20% for an extra margin of error.