### PR TITLE
fix CSV parsing

### DIFF
--- a/src/adsb_api/utils/provider.py
+++ b/src/adsb_api/utils/provider.py
@@ -314,7 +314,7 @@ class RedisVRS:
             return None
         data = data.decode()
         print("vrsx", icao, data)
-        name, _, iata, location, countryiso2, lat, lon, alt_feet = data.split(",")
+        name, _, iata, location, countryiso2, lat, lon, alt_feet = list(csv.reader([data]))[0]
         ret = {
             "name": name,
             "icao": icao,


### PR DESCRIPTION
The routes CSV contains airport names with commas, correctly quoted with double quotes. Using split(',') on those lines will throw an error. But the CSV parser can handle a single line if you ask nicely enough.

Hat tip to Katia for explaining most of this to me and to https://stackoverflow.com/questions/35822822/parse-a-single-csv-string for the right approach to use the csv.reader().